### PR TITLE
add dependencies for awss3 property source

### DIFF
--- a/bidms-config-server/build.gradle
+++ b/bidms-config-server/build.gradle
@@ -35,6 +35,8 @@ apply plugin: 'org.springframework.boot'
 dependencies {
     compile 'org.springframework.cloud:spring-cloud-config-server'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.958')
+    implementation 'com.amazonaws:aws-java-sdk-s3'
 }
 
 war {

--- a/bidms-config-server/build.gradle
+++ b/bidms-config-server/build.gradle
@@ -35,8 +35,11 @@ apply plugin: 'org.springframework.boot'
 dependencies {
     compile 'org.springframework.cloud:spring-cloud-config-server'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.958')
-    implementation 'com.amazonaws:aws-java-sdk-s3'
+    // Optionally enable AWS S3 support by setting the enableConfigServerS3
+    // property to true when building.
+    if (project.hasProperty("enableConfigServerS3") && project.getProperty("enableConfigServerS3")) {
+        runtimeOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: versions.awsSdk
+    }
 }
 
 war {

--- a/versions.properties
+++ b/versions.properties
@@ -65,3 +65,8 @@ postgresql=42.2.18
 orgJson=20201115
 
 apacheDsEmbedded=0.4
+
+# This is optionally used for config server AWS S3 support.  By default,
+# it's not used.  Enable with -PenableConfigServerS3=true when building.
+# https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-s3
+awsSdk=1.11.959


### PR DESCRIPTION
@bkoehm I had to add these dependencies to get bidms-config to start after adding `awss3` as an active profile.